### PR TITLE
Implement test.hcl tests with rust

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -1,6 +1,7 @@
 # Notes
 
 - Language file parsing and generating build definitions
+ - shells?
  -
 - Building (in order building, in a sandbox)
 - End user tooling and ergonomics
@@ -13,12 +14,91 @@
 ```json
 {"78as69f8a76ds9fa86": {
     "shell": ["{ asdf6asdf69as8d76a }/busybox-x86_64", "sh"],
-    "dependencies": ["asdf6asdf69as8d76a", "/user/maxm/file"],
     "script": "echo hi",
+    "dependencies": ["asdf6asdf69as8d76a", "/user/maxm/file"],
     "env" : { "Lake":"fish" },
 
     "network": false,
     "arch": "linux-x86",
 }}
 
+{"78as69f8a76ds9fa86": {
+    "builder": "{ asdf6asdf69as8d76a }/busybox-x86_64",
+    "args": ["sh" "-c" "echo hi", "/store/asfas9dyfasodf7896as89df6/magicfilename.sh"],
+    "dependencies": ["asdf6asdf69as8d76a", "/user/maxm/file"],
+    "env" : { "Lake":"fish" },
+
+    "network": false,
+    "arch": "linux-x86",
+}}
+
+
+    "build": "{ asdf6asdf69as8d76a }/python",
+    "args": ["sh" "-c" "echo hi"],
+
+```
+
+
+```
+bash -c "echo hi"
+
+echo 'echo "hi"' > script.sh
+bash ./script.sh
+```
+
+```hcl
+store "go" {
+  inputs = [go_src]
+  shell  = ["${busybox_tar}/busybox-x86_64", "sh"]
+  script = <<EOH
+    cp -r ${go_src} ./src
+    cd ./src/src
+    sh ./build-complete.sh
+    mkdir -p $out/bin $out/lib
+    cp -r ./output/bin $out/bin
+    cp -r ./output/lib $out/lib
+  EOH
+}
+
+command "go_shell" {
+  inputs = [go]
+  shell  = ["${busybox_tar}/busybox-x86_64", "sh"]
+  script = <<EOH
+    PATH=$PATH:${go}/bin
+    PATH=$PATH:${busybox_tar}/bin
+    sh $@
+  EOH
+}
+
+command "new_shell" {
+  inputs = [go, bash, mysql, librdkafka]
+  shell = stdlib.depComposer
+}
+
+
+shell "new_shell" {
+  inputs
+}
+
+shell "go" {
+  bin_path = "{go}/bin"
+  ...
+}
+
+store "mything" {
+  inputs = ["./*.go"]
+  shell = ["${go_shell}"]
+  script = "go build"
+}
+
+store "mything" {
+  inputs = ["./*.go"]
+  shell = ["${go}/bin/go", "build"]
+  script = "."
+}
+
+store "busybox_store" {
+  inputs = [busybox_tar, "./install.sh", ]
+  shell  = ["${busybox_tar}/busybox-x86_64", "sh", "install.sh"]
+}
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,14 +309,17 @@ mod tests {
             let result = parse_body(lakefile.into());
             if err_contains != "" && result.is_ok() {
                 panic!(
-                    "Test {name} was expected to return an error "
-                        + "containing {:?}, but no error was found",
+                    "Test {name} was expected to return an error containing {:?}, but no error was found",
                     err_contains
                 )
             } else if result.is_err() {
                 let err_msg = format!("{:?}", result.err().unwrap());
                 if !err_msg.contains(&err_contains) {
-                    panic!("\n\nTest {name} was expected to return an error containing:\n\t{:?}\nit instead returned the error:\n\t{:?}\n", err_contains, err_msg)
+                    panic!(
+                        "\n\nTest {name} was expected to return an error containing:\n\t{:?}\nit instead returned the error:\n\t{:?}\n",
+                        err_contains,
+                        err_msg,
+                    )
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,6 +204,8 @@ fn find_variables(val: &hcl::Value) -> Vec<String> {
             let tmpl = hcl::Template::from_str(&s).unwrap();
             let elems = tmpl.elements();
             for elem in elems {
+                // Uncomment to view pretty-print of expanded element. Will be
+                // helpful when implementing ::Directive
                 // println!("{:?}", elem);
                 match elem {
                     hcl::template::Element::Interpolation(int) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -314,6 +314,8 @@ mod tests {
                     "Test {name} was expected to return an error containing {:?}, but no error was found",
                     err_contains
                 )
+            } else if err_contains == "" && result.is_err() {
+                result.expect(format!("test {name} errored unexpectedly").as_str());
             } else if result.is_err() {
                 let err_msg = format!("{:?}", result.err().unwrap());
                 if !err_msg.contains(&err_contains) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -291,15 +291,14 @@ mod tests {
         let body: hcl::Body = hcl::from_reader(f)?;
         for entity in body.into_inner() {
             let (name, err_contains, lakefile) = match entity {
-                hcl::Structure::Block(block) => {
-                    let name = block.labels.first().unwrap().clone().into_inner();
-                    let err_contains = get_err_contains(&block.body);
-                    let lakefile = get_lakefile(&block.body).expect("lakefile should exist");
-                    (name, err_contains, lakefile)
-                }
                 hcl::Structure::Attribute(attr) => {
                     panic!("Attributes are not allowed in test.hcl: {:?}", attr)
                 }
+                hcl::Structure::Block(block) => (
+                    block.labels.first().unwrap().clone().into_inner(),
+                    get_err_contains(&block.body),
+                    get_lakefile(&block.body).expect("lakefile should exist within test block"),
+                ),
             };
 
             println!("\nRunning test: {:#?}", name);
@@ -309,7 +308,11 @@ mod tests {
 
             let result = parse_body(lakefile.into());
             if err_contains != "" && result.is_ok() {
-                panic!("Test {name} was expected to return an error containing {:?}, but no error was found", err_contains)
+                panic!(
+                    "Test {name} was expected to return an error "
+                        + "containing {:?}, but no error was found",
+                    err_contains
+                )
             } else if result.is_err() {
                 let err_msg = format!("{:?}", result.err().unwrap());
                 if !err_msg.contains(&err_contains) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,7 +204,7 @@ fn find_variables(val: &hcl::Value) -> Vec<String> {
             let tmpl = hcl::Template::from_str(&s).unwrap();
             let elems = tmpl.elements();
             for elem in elems {
-                println!("{:?}", elem);
+                // println!("{:?}", elem);
                 match elem {
                     hcl::template::Element::Interpolation(int) => {
                         find_expression_variables(&mut variables, &int.expr);
@@ -249,5 +249,69 @@ fn find_expression_variables(variables: &mut Vec<String>, expr: &hcl::Expression
     };
     for exp in exprs {
         find_expression_variables(variables, &exp);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{parse_body, Result};
+    use hcl;
+    use std::fs::File;
+
+    fn get_err_contains(block: &hcl::Body) -> String {
+        for attr in block.attributes() {
+            if attr.key.clone().into_inner() == "err_contains" {
+                if let hcl::Expression::String(str) = attr.expr.clone() {
+                    return str;
+                } else {
+                    panic!(
+                        "err_contains expression is not the correct type: {:?}",
+                        attr.expr
+                    )
+                }
+            } else {
+                panic!("Unexpected attribute found: {:#?}", attr);
+            }
+        }
+        String::new()
+    }
+    fn get_lakefile(block: &hcl::Body) -> Option<hcl::Body> {
+        for block in block.blocks() {
+            if block.identifier.clone().into_inner() == "file" {
+                return Some(block.body.clone());
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn test_hcl() -> Result<()> {
+        // Tests run from proj root
+        let f = File::open("./src/test.hcl")?;
+        let body: hcl::Body = hcl::from_reader(f)?;
+        for entity in body.into_inner() {
+            match entity {
+                hcl::Structure::Block(block) => {
+                    let name = block.labels.first().unwrap().clone().into_inner();
+                    println!("Running test: {:#?}", name);
+                    let err_contains = get_err_contains(&block.body);
+                    println!("Err contains: {:#?}", err_contains);
+                    let lakefile = get_lakefile(&block.body).expect("lakefile should exist");
+                    let result = parse_body(lakefile.into());
+                    if err_contains != "" && result.is_ok() {
+                        panic!("Test {name} was expected to return an error containing {:?}, but no error was found", err_contains)
+                    } else if result.is_err() {
+                        let err_msg = format!("{:?}", result.err().unwrap());
+                        if !err_msg.contains(&err_contains) {
+                            panic!("\n\nTest {name} was expected to return an error containing:\n\t{:?}\nit instead returned the error:\n\t{:?}\n", err_contains, err_msg)
+                        }
+                    }
+                }
+                hcl::Structure::Attribute(attr) => {
+                    panic!("Attributes are not allowed in test.hcl: {:?}", attr)
+                }
+            };
+        }
+        Ok(())
     }
 }

--- a/src/test.hcl
+++ b/src/test.hcl
@@ -1,5 +1,5 @@
 test "identifier store name conflict" {
-  err_contains = "Duplicate name"
+  err_contains = "duplicate name"
 
   file "Lakefile" {
     empty_store = "foo"
@@ -11,7 +11,7 @@ test "identifier store name conflict" {
 }
 
 test "store and target name conflict" {
-  err_contains = "Duplicate name"
+  err_contains = "duplicate name"
 
   file "Lakefile" {
     command "empty_store" {
@@ -27,7 +27,7 @@ test "store and target name conflict" {
 
 
 test "basic out of order references" {
-  err_contains = "unexpected block type"
+  err_contains = "InvalidBlockError"
   file "Lakefile" {
     unexpected "empty_store" {}
   }
@@ -88,7 +88,7 @@ test "basic functionality" {
 # }
 
 test "store comand circular reference" {
-  err_contains = "Circular reference"
+  err_contains = "WouldCycle"
   file "Lakefile" {
     command "a" {
       inputs = [c]
@@ -106,7 +106,7 @@ test "store comand circular reference" {
 }
 
 test "argument circular reference" {
-  err_contains = "Circular reference"
+  err_contains = "WouldCycle"
   file "Lakefile" {
     a = c
     b = a
@@ -115,7 +115,7 @@ test "argument circular reference" {
 }
 
 test "mixed argument store command circular reference" {
-  err_contains = "Circular reference"
+  err_contains = "WouldCycle"
   file "Lakefile" {
     a = c
     command "b" { inputs = [a] }

--- a/src/test.hcl
+++ b/src/test.hcl
@@ -49,7 +49,7 @@ test "basic functionality" {
       network = true
     }
 
-    target "busybox" {
+    command "busybox" {
       inputs = [busybox_store]
       shell  = ["${busybox_tar}/bin/busybox", "sh"]
       script = <<EOH


### PR DESCRIPTION
Just got the tests working, they are all passing on some level but I had to tolerate uglier error messages. I think this is a good -enough start that we can improve later.

Errant notes.md were added in this PR, can move/remove if desired. 

Example output:
```
$ cargo test -- --nocapture
   Compiling lake v0.1.0 (/Users/maxm/go/src/github.com/maxmcd/lake)
    Finished test [unoptimized + debuginfo] target(s) in 1.35s
     Running unittests src/main.rs (target/debug/deps/lake-089baab4e3e04f3e)

running 1 test

Running test: "identifier store name conflict"
	Confirming that err contains: "duplicate name"

Running test: "store and target name conflict"
	Confirming that err contains: "duplicate name"

Running test: "basic out of order references"
	Confirming that err contains: "InvalidBlockError"

Running test: "basic functionality"

Running test: "store comand circular reference"
	Confirming that err contains: "WouldCycle"

Running test: "argument circular reference"
	Confirming that err contains: "WouldCycle"

Running test: "mixed argument store command circular reference"
	Confirming that err contains: "WouldCycle"
test tests::test_hcl ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```